### PR TITLE
🔧 Fix outdated code snippet in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ class ViewController: UIViewController {
         }
         
         // And finally add it to your MKMapView
-        mapView.add(tileOverlay)
+        mapView.addOverlay(tileOverlay)
     }
     
 }


### PR DESCRIPTION
Fixes the 
```swift
mapView.add(tileOverlay)
```
line in readme to support the latest API
```swift
mapView.addOverlay(tileOverlay)
```